### PR TITLE
mark-devkit: Bump virtual/cdrtools-0

### DIFF
--- a/virtual/cdrtools/cdrtools-0.ebuild
+++ b/virtual/cdrtools/cdrtools-0.ebuild
@@ -1,0 +1,11 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+DESCRIPTION="Virtual for command-line recorders cdrtools and cdrkit"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+
+RDEPEND="|| ( app-cdr/cdrtools app-cdr/cdrkit )"


### PR DESCRIPTION
Automatic bump of package virtual/cdrtools-0 for branch mark-xl by mark-bot