### PR TITLE
mark-devkit: Bump dev-util/scons-4.9.0-r1

### DIFF
--- a/dev-util/scons/scons-4.9.0-r1.ebuild
+++ b/dev-util/scons/scons-4.9.0-r1.ebuild
@@ -16,7 +16,7 @@ RESTRICT="test"
 SLOT="0"
 LICENSE="MIT"
 KEYWORDS="*"
-S="${WORKDIR}/SCons-4.9.0"
+S="${WORKDIR}/scons-4.9.0"
 
 if [ "$PN"  == 'scons-compat' ]; then
 	S="${WORKDIR}/scons-${PV}"


### PR DESCRIPTION
Automatic bump of package dev-util/scons-4.9.0-r1 for branch mark-iii by mark-bot