### PR TITLE
mark-devkit: Bump dev-cpp/websocketpp-0.8.2

### DIFF
--- a/dev-cpp/websocketpp/Manifest
+++ b/dev-cpp/websocketpp/Manifest
@@ -1,0 +1,1 @@
+DIST websocketpp-0.8.2-release.tar.gz 701364 SHA512 b2afc63edb69ce81a3a6c06b3d857b3e8820f0e22300ac32bb20ab30ff07bd58bd5ada3e526ed8ab52de934e0e3a26cad2118b0e68ecf3e5e9e8d7101348fd06

--- a/dev-cpp/websocketpp/files/websocketpp-0.7.0-cmake-install.patch
+++ b/dev-cpp/websocketpp/files/websocketpp-0.7.0-cmake-install.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f60caa1..9ff2211 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,13 +15,20 @@ set (WEBSOCKETPP_VERSION ${WEBSOCKETPP_MAJOR_VERSION}.${WEBSOCKETPP_MINOR_VERSIO
+ 
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+ 
++get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
++if ("${LIB64}" STREQUAL "TRUE")
++  set(LIBSUFFIX 64)
++else()
++  set(LIBSUFFIX "")
++endif()
++
+ set(INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
++set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
+ if (WIN32 AND NOT CYGWIN)
+-  set (DEF_INSTALL_CMAKE_DIR cmake)
++  set (INSTALL_CMAKE_DIR cmake)
+ else ()
+-  set (DEF_INSTALL_CMAKE_DIR lib/cmake/websocketpp)
++  set (INSTALL_CMAKE_DIR ${LIB_INSTALL_DIR}/cmake/websocketpp)
+ endif ()
+-set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
+ 
+ # Make relative paths absolute (needed later on)
+ foreach (p INCLUDE CMAKE)

--- a/dev-cpp/websocketpp/files/websocketpp-0.8.1-disable-test_transport-test_transport_asio_timers.patch
+++ b/dev-cpp/websocketpp/files/websocketpp-0.8.1-disable-test_transport-test_transport_asio_timers.patch
@@ -1,0 +1,46 @@
+--- a/test/transport/CMakeLists.txt
++++ b/test/transport/CMakeLists.txt
+@@ -1,24 +1,24 @@
+ if (OPENSSL_FOUND)
+ 
+-# Test transport integration
+-file (GLOB SOURCE integration.cpp)
+-
+-init_target (test_transport)
+-build_test (${TARGET_NAME} ${SOURCE})
+-link_boost ()
+-link_openssl()
+-final_target ()
+-set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "test")
+-
+-# Test transport asio timers
+-file (GLOB SOURCE asio/timers.cpp)
+-
+-init_target (test_transport_asio_timers)
+-build_test (${TARGET_NAME} ${SOURCE})
+-link_boost ()
+-link_openssl()
+-final_target ()
+-set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "test")
++## Test transport integration
++#file (GLOB SOURCE integration.cpp)
++#
++#init_target (test_transport)
++#build_test (${TARGET_NAME} ${SOURCE})
++#link_boost ()
++#link_openssl()
++#final_target ()
++#set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "test")
++#
++## Test transport asio timers
++#file (GLOB SOURCE asio/timers.cpp)
++#
++#init_target (test_transport_asio_timers)
++#build_test (${TARGET_NAME} ${SOURCE})
++#link_boost ()
++#link_openssl()
++#final_target ()
++#set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "test")
+ 
+ # Test transport asio security
+ file (GLOB SOURCE asio/security.cpp)

--- a/dev-cpp/websocketpp/files/websocketpp-0.8.2-fix-boost_find_component.patch
+++ b/dev-cpp/websocketpp/files/websocketpp-0.8.2-fix-boost_find_component.patch
@@ -1,0 +1,24 @@
+From 36b73da8958927f975b3d01a062aa6c0e149d97f Mon Sep 17 00:00:00 2001
+From: Peter Thorson <git@zaphoyd.com>
+Date: Mon, 27 Apr 2020 10:34:06 -0500
+Subject: [PATCH] [cmake] Remove quotes that was making it hard for cmake to
+ find newer boost versions. fixes #855
+
+---
+ CMakeLists.txt | 2 +-
+ changelog.md   | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e9c80e84..ffcd8583b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -215,7 +215,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
+     set (Boost_USE_MULTITHREADED TRUE)
+     set (Boost_ADDITIONAL_VERSIONS "1.39.0" "1.40.0" "1.41.0" "1.42.0" "1.43.0" "1.44.0" "1.46.1") # todo: someone who knows better spesify these!
+ 
+-    find_package (Boost 1.39.0 COMPONENTS "${WEBSOCKETPP_BOOST_LIBS}")
++    find_package (Boost 1.39.0 COMPONENTS ${WEBSOCKETPP_BOOST_LIBS})
+ 
+     if (Boost_FOUND)
+         # Boost is a project wide global dependency.

--- a/dev-cpp/websocketpp/files/websocketpp-0.8.2-fix-clang.patch
+++ b/dev-cpp/websocketpp/files/websocketpp-0.8.2-fix-clang.patch
@@ -1,0 +1,25 @@
+From 2c355d9ef0f3ed73fa96d0c6c31293086df36d74 Mon Sep 17 00:00:00 2001
+From: Peter Thorson <git@zaphoyd.com>
+Date: Sun, 19 Apr 2020 22:33:24 -0500
+Subject: [PATCH] Fix typo in CMakeLists.txt that caused CXX_FLAGS to be
+ improperly quoted. Removed unnecessary hardcoded dependency on libc++ for
+ clang. fixes #859
+
+---
+ CMakeLists.txt | 2 +-
+ changelog.md   | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dcf90d1c8..3e9c80e84 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -152,7 +152,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
+         endif()
+         set (WEBSOCKETPP_PLATFORM_TLS_LIBS ssl crypto)
+         set (WEBSOCKETPP_BOOST_LIBS system thread)
+-        set (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++0x -stdlib=libc++") # todo: is libc++ really needed here?
++        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+         if (NOT APPLE)
+             add_definitions (-DNDEBUG -Wall -Wno-padded) # todo: should we use CMAKE_C_FLAGS for these?
+         endif ()

--- a/dev-cpp/websocketpp/websocketpp-0.8.2.ebuild
+++ b/dev-cpp/websocketpp/websocketpp-0.8.2.ebuild
@@ -1,0 +1,47 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="C++/Boost Asio based websocket client/server library"
+HOMEPAGE="https://www.zaphoyd.com/websocketpp"
+SRC_URI="https://github.com/zaphoyd/${PN}/archive/${PV}.tar.gz -> ${P}-release.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="*"
+IUSE="examples test"
+RESTRICT="!test? ( test )"
+
+DEPEND="test? ( dev-libs/boost )"
+RDEPEND="dev-libs/boost"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.7.0-cmake-install.patch
+	# disable tests that are timing sensitive
+	# https://bugzilla.redhat.com/show_bug.cgi?id=1461069
+	"${FILESDIR}"/${PN}-0.8.1-disable-test_transport-test_transport_asio_timers.patch
+	# https://github.com/zaphoyd/websocketpp/commit/36b73da8958927f975b3d01a062aa6c0e149d97f
+	"${FILESDIR}"/${P}-fix-boost_find_component.patch
+	# https://github.com/zaphoyd/websocketpp/commit/2c355d9ef0f3ed73fa96d0c6c31293086df36d74
+	"${FILESDIR}"/${P}-fix-clang.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_CPP11=ON
+		-DBUILD_TESTS="$(usex test)"
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}


### PR DESCRIPTION
Automatic bump of package dev-cpp/websocketpp-0.8.2 for branch mark-unstable by mark-bot