### PR TITLE
mark-devkit: Bump dev-util/cmake-3.24.1-r1

### DIFF
--- a/dev-util/cmake/cmake-3.24.1-r1.ebuild
+++ b/dev-util/cmake/cmake-3.24.1-r1.ebuild
@@ -55,6 +55,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.8.10.2-FindPythonLibs.patch
 	"${FILESDIR}"/${PN}-3.9.0_rc2-FindPythonInterp.patch
 	"${FILESDIR}"/${PN}-3.18.0-filter_distcc_warning.patch
+	"${FILESDIR}"/${PN}-3.24.1-curl.patch
 )
 
 cmake_src_bootstrap() {

--- a/dev-util/cmake/files/cmake-3.24.1-curl.patch
+++ b/dev-util/cmake/files/cmake-3.24.1-curl.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/cmCurl.cxx b/Source/cmCurl.cxx
+index b9133ed7d47..0cf8a71a72d 100644
+--- a/Source/cmCurl.cxx
++++ b/Source/cmCurl.cxx
+@@ -170,7 +170,7 @@ std::string cmCurlSetNETRCOption(::CURL* curl, const std::string& netrc_level,
+                                  const std::string& netrc_file)
+ {
+   std::string e;
+-  CURL_NETRC_OPTION curl_netrc_level = CURL_NETRC_LAST;
++  long curl_netrc_level = CURL_NETRC_LAST;
+   ::CURLcode res;
+
+   if (!netrc_level.empty()) {


### PR DESCRIPTION
Automatic bump of package dev-util/cmake-3.24.1-r1 for branch mark-iii by mark-bot