### PR TITLE
mark-devkit: Bump dev-cpp/clucene-2.3.3.4-r7

### DIFF
--- a/dev-cpp/clucene/clucene-2.3.3.4-r7.ebuild
+++ b/dev-cpp/clucene/clucene-2.3.3.4-r7.ebuild
@@ -43,11 +43,6 @@ src_prepare() {
 		-e '/ADD_SUBDIRECTORY (src\/ext)/d' \
 		CMakeLists.txt || die
 	rm -rf src/ext || die
-
-	# macaroni-os/mark-issues#419
-	sed -i \
-		-e "s|^CL_NS_USE(util)|#include <ctime>\nCL_NS_USE(util)|g" \
-		src/core/CLucene/document/DateTools.cpp || die
 }
 
 src_configure() {


### PR DESCRIPTION
Automatic bump of package dev-cpp/clucene-2.3.3.4-r7 for branch mark-unstable by mark-bot