### PR TITLE
mark-devkit: Bump dev-vcs/hub-2.14.2-r1

### DIFF
--- a/dev-vcs/hub/hub-2.14.2-r1.ebuild
+++ b/dev-vcs/hub/hub-2.14.2-r1.ebuild
@@ -59,7 +59,7 @@ BDEPEND="sys-apps/groff"
 RDEPEND=">=dev-vcs/git-1.7.3"
 
 post_src_unpack() {
-	mv "${WORKDIR}"/mislav-hub-* "${S}" || die
+	mv "${WORKDIR}"/github-hub-* "${S}" || die
 }
 
 src_compile() {


### PR DESCRIPTION
Automatic bump of package dev-vcs/hub-2.14.2-r1 for branch mark-iii by mark-bot