### PR TITLE
mark-devkit: Bump dev-libs/redland-1.0.17-r3

### DIFF
--- a/dev-libs/redland/redland-1.0.17-r3.ebuild
+++ b/dev-libs/redland/redland-1.0.17-r3.ebuild
@@ -30,10 +30,6 @@ MAKEOPTS="${MAKEOPTS} -j1" #500574, required for both src_compile() and src_inst
 src_prepare() {
 	default
 	elibtoolize # NOTE: this is for fbsd .so version
-
-	# error: unknown type name 'my_bool'
-	sed -e 's|my_bool value=(context->reconnect)|bool value=(context->reconnect)|g' -i \
-		src/rdf_storage_mysql.c
 }
 
 src_configure() {


### PR DESCRIPTION
Automatic bump of package dev-libs/redland-1.0.17-r3 for branch mark-iii by mark-bot