### PR TITLE
mark-devkit: Bump dev-util/jetbrains-toolbox-2.6.2-r1

### DIFF
--- a/dev-util/jetbrains-toolbox/jetbrains-toolbox-2.6.2-r1.ebuild
+++ b/dev-util/jetbrains-toolbox/jetbrains-toolbox-2.6.2-r1.ebuild
@@ -36,7 +36,7 @@ src_install() {
 
 	mkdir -p "${ED}"/usr/share/applications
 	insinto /usr/share/applications
-	doins "${FILESDIR}/${PN}.desktop"
+	doins "${REPODIR}/dev-util/jetbrains/files/${PN}.desktop"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Automatic bump of package dev-util/jetbrains-toolbox-2.6.2-r1 for branch mark-iii by mark-bot