### PR TITLE
mark-devkit: Bump dev-util/source-highlight-3.1.8-r2

### DIFF
--- a/dev-util/source-highlight/source-highlight-3.1.8-r2.ebuild
+++ b/dev-util/source-highlight/source-highlight-3.1.8-r2.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~s
 SLOT="0"
 IUSE="doc static-libs"
 
-RDEPEND="dev-libs/boost
+RDEPEND=">=dev-libs/boost-1.62.0:=[threads]
 	dev-util/ctags"
 DEPEND="${RDEPEND}"
 BDEPEND=""


### PR DESCRIPTION
Automatic bump of package dev-util/source-highlight-3.1.8-r2 for branch mark-unstable by mark-bot