### PR TITLE
mark-devkit: [mark-unstable] Bump sys-apps/miscfiles-1.5-r1

### DIFF
--- a/sys-apps/miscfiles/miscfiles-1.5-r1.ebuild
+++ b/sys-apps/miscfiles/miscfiles-1.5-r1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="*"
 IUSE="minimal"
 src_prepare() {
 	default
-	mv "${WORKDIR}"/UnicodeData-${UNI_PV}.txt unicode || die
+	mv "${WORKDIR}"/miscfiles-UnicodeData-10.0.0.txt unicode || die
 }
 src_configure() {
 	econf --datadir="${EPREFIX%/}"/usr/share/misc


### PR DESCRIPTION
Automatic bump of package sys-apps/miscfiles-1.5-r1 for branch mark-unstable by mark-bot