### PR TITLE
mark-devkit: [mark-iii] Bump dev-libs/dbus-glib-0.110-r1

### DIFF
--- a/dev-libs/dbus-glib/dbus-glib-0.110-r1.ebuild
+++ b/dev-libs/dbus-glib/dbus-glib-0.110-r1.ebuild
@@ -19,7 +19,6 @@ CDEPEND="
 	>=sys-apps/dbus-1.8[${MULTILIB_USEDEP}]
 "
 DEPEND="${CDEPEND}
-	>=dev-util/glib-utils-2.40
 	>=dev-util/gtk-doc-am-1.14
 	virtual/pkgconfig
 "


### PR DESCRIPTION
Automatic bump of package dev-libs/dbus-glib-0.110-r1 for branch mark-iii by mark-bot