### PR TITLE
mark-devkit: [mark-iii] Bump dev-util/cmake-3.31.9-r1

### DIFF
--- a/dev-util/cmake/cmake-3.31.9-r1.ebuild
+++ b/dev-util/cmake/cmake-3.31.9-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 CMAKE_MAKEFILE_GENERATOR="emake"
-CMAKE_REMOVE_MODULES_LIST=( nonde )
+CMAKE_REMOVE_MODULES_LIST=( none )
 SITEFILE="50${PN}-mark.el"
 inherit bash-completion-r1 cmake elisp-common flag-o-matic multiprocessing toolchain-funcs xdg-utils
 


### PR DESCRIPTION
Automatic bump of package dev-util/cmake-3.31.9-r1 for branch mark-iii by mark-bot