### PR TITLE
mark-devkit: [mark-31] Bump dev-libs/libdbusmenu-16.04.0-r2

### DIFF
--- a/dev-libs/libdbusmenu/libdbusmenu-16.04.0-r2.ebuild
+++ b/dev-libs/libdbusmenu/libdbusmenu-16.04.0-r2.ebuild
@@ -28,7 +28,6 @@ RDEPEND="
 # tests also have optional dep on valgrind which we do not enforce
 DEPEND="${RDEPEND}
 	app-text/gnome-doc-utils
-	dev-util/glib-utils
 	dev-util/intltool
 	sys-devel/gettext
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package dev-libs/libdbusmenu-16.04.0-r2 for branch mark-31 by mark-bot