### PR TITLE
mark-devkit: [mark-31] Bump dev-libs/libindicator-12.10.1-r302

### DIFF
--- a/dev-libs/libindicator/libindicator-12.10.1-r302.ebuild
+++ b/dev-libs/libindicator/libindicator-12.10.1-r302.ebuild
@@ -16,7 +16,6 @@ IUSE="test"
 RDEPEND=">=dev-libs/glib-2.22[${MULTILIB_USEDEP}]
 	>=x11-libs/gtk+-3.2:3[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 	virtual/pkgconfig[${MULTILIB_USEDEP}]
 	test? ( dev-util/dbus-test-runner )"
 


### PR DESCRIPTION
Automatic bump of package dev-libs/libindicator-12.10.1-r302 for branch mark-31 by mark-bot